### PR TITLE
Fix Gazebo sourcing and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@
 .cache/*
 /venv
 
-gazebo_init/*
-!gazebo_init/README.md
+**/gazebo_init/*
+!**/gazebo_init/README.md
 
 *IfcConvert
 **/__pycache__/

--- a/docker/nav2_example/Dockerfile
+++ b/docker/nav2_example/Dockerfile
@@ -31,6 +31,7 @@ RUN sudo apt-get update && \
 
 # Source ROS workspace automatically when new terminal is opened
 RUN sudo echo ". /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc
+RUN sudo echo ". /usr/share/gazebo/setup.bash" >> ~/.bashrc
 
 
 # Source ROS in the main terminal


### PR DESCRIPTION
Gazebo was not starting properly in my environment without sourcing /usr/share/gazebo/setup.bash, so added that to nav example's Dockerfile.

Fixed matching of gazebo_init in the sub-directories in .gitignore.