### PR TITLE
Cancel Mission on STOP

### DIFF
--- a/task_manager/task_manager/tasks/mission.py
+++ b/task_manager/task_manager/tasks/mission.py
@@ -81,15 +81,13 @@ class Mission:
             mission_result.skipped = False
 
             if subtask_result.task_status != TaskStatus.DONE:
-                if subtask.allow_skipping:
+                if subtask.allow_skipping and not goal_handle.is_cancel_requested:
                     mission_result.skipped = True
                     continue
 
-                if subtask_result.task_status == TaskStatus.CANCELED and goal_handle.is_cancel_requested:
-                    # Need to also check if the cancel was requested. If the goal was cancelled
-                    # through a system task, we cannot set the status to be cancelled and must abort instead.
+                if goal_handle.is_cancel_requested:
                     goal_handle.canceled()
-                else:  # Could be ERROR or IN_PROGRESS if the goal couldn't be cancelled
+                else:
                     goal_handle.abort()
                 return result
 
@@ -102,7 +100,7 @@ class Mission:
         return TaskSpecs(
             task_name="system/mission",
             blocking=False,
-            cancel_on_stop=False,
+            cancel_on_stop=True,
             topic=mission_topic,
             cancel_reported_as_success=False,
             reentrant=False,

--- a/task_manager/task_manager/tasks/mission.py
+++ b/task_manager/task_manager/tasks/mission.py
@@ -87,7 +87,7 @@ class Mission:
 
                 if goal_handle.is_cancel_requested:
                     goal_handle.canceled()
-                else:
+                else:  # If mission is not cancelled but a subtask fail, we abort the mission
                     goal_handle.abort()
                 return result
 

--- a/task_manager/task_manager/tasks/mission.py
+++ b/task_manager/task_manager/tasks/mission.py
@@ -17,6 +17,7 @@
 import uuid
 from typing import Callable
 
+from icecream import ic
 # ROS
 from rclpy.action.server import ActionServer, CancelResponse, ServerGoalHandle
 from rclpy.callback_groups import ReentrantCallbackGroup
@@ -85,9 +86,13 @@ class Mission:
                     mission_result.skipped = True
                     continue
 
-                if goal_handle.is_cancel_requested:
+                # If the subtask has been cancelled together with the mission, we cancel the mission
+                # If the subtask has been cancelled/failed/indefinitely in progress, we abort the mission
+                # If the mission has been cancelled but the subtask is failed/indefinitely in progress,
+                # we abort the mission
+                if subtask_result.task_status == TaskStatus.CANCELED and goal_handle.is_cancel_requested:
                     goal_handle.canceled()
-                else:  # If mission is not cancelled but a subtask fail, we abort the mission
+                else:
                     goal_handle.abort()
                 return result
 

--- a/task_manager/task_manager/tasks/mission.py
+++ b/task_manager/task_manager/tasks/mission.py
@@ -17,7 +17,6 @@
 import uuid
 from typing import Callable
 
-from icecream import ic
 # ROS
 from rclpy.action.server import ActionServer, CancelResponse, ServerGoalHandle
 from rclpy.callback_groups import ReentrantCallbackGroup

--- a/task_manager/test/test_mission.py
+++ b/task_manager/test/test_mission.py
@@ -84,6 +84,32 @@ class MissionUnittest(unittest.TestCase):
             mock_goal_handle.abort.assert_called_once()
             self.assertEqual(result.mission_results[0].task_status, TaskStatus.ERROR)
 
+    def test_mission_not_successful_skipping_task(self):
+        """Tests that the status of the subtasks are set correctly when the subtasks fail or are cancelled, or if the
+        Mission is cancelled."""
+        request = MissionAction.Goal(
+            subtasks=[SubtaskGoal(task_name="test/mock_subtask", allow_skipping=True, task_data="{}")]
+        )
+        mock_goal_handle = Mock(request=request)
+        mock_goal_handle.is_cancel_requested = True
+
+        with self.subTest("mission_canceled"):
+            self.mission.execute_task_cb.return_value = ExecuteTask.Result(
+                task_status=TaskStatus.CANCELED, task_result="{}"
+            )
+            result = self.mission.execute_cb(goal_handle=mock_goal_handle)
+            mock_goal_handle.canceled.assert_called_once()
+            self.assertEqual(result.mission_results[0].task_status, TaskStatus.CANCELED)
+
+        mock_goal_handle.reset_mock()
+        with self.subTest("mission_error"):
+            self.mission.execute_task_cb.return_value = ExecuteTask.Result(
+                task_status=TaskStatus.ERROR, task_result="{}"
+            )
+            result = self.mission.execute_cb(goal_handle=mock_goal_handle)
+            mock_goal_handle.abort.assert_called_once()
+            self.assertEqual(result.mission_results[0].task_status, TaskStatus.ERROR)
+
     def test_skipping_subtask(self):
         """Tests that even though a subtask is aborted, no error is raised when the task is allowed to be skipped."""
         request = MissionAction.Goal()
@@ -97,9 +123,9 @@ class MissionUnittest(unittest.TestCase):
         expected_result.mission_results = [
             SubtaskResult(task_name="test/mock_subtask", task_status=TaskStatus.ERROR, skipped=True, task_id="123")
         ]
-        mock_handle = Mock(request=request)
-        mock_handle.is_cancel_requested = False
-        result = self.mission.execute_cb(goal_handle=mock_handle)
+        mock_goal_handle = Mock(request=request)
+        mock_goal_handle.is_cancel_requested = False
+        result = self.mission.execute_cb(goal_handle=mock_goal_handle)
         self.assertEqual(result, expected_result)
 
 

--- a/task_manager/test/test_mission.py
+++ b/task_manager/test/test_mission.py
@@ -85,8 +85,7 @@ class MissionUnittest(unittest.TestCase):
             self.assertEqual(result.mission_results[0].task_status, TaskStatus.ERROR)
 
     def test_mission_not_successful_skipping_task(self):
-        """Tests that the status of the subtasks are set correctly when the subtasks fail or are cancelled, or if the
-        Mission is cancelled."""
+        """Tests that the mission is properly cancelled or aborted when a subtask is skipped."""
         request = MissionAction.Goal(
             subtasks=[SubtaskGoal(task_name="test/mock_subtask", allow_skipping=True, task_data="{}")]
         )

--- a/task_manager/test/test_mission.py
+++ b/task_manager/test/test_mission.py
@@ -85,7 +85,7 @@ class MissionUnittest(unittest.TestCase):
             self.assertEqual(result.mission_results[0].task_status, TaskStatus.ERROR)
 
     def test_skipping_subtask(self):
-        """Tests that even tho a subtask is aborted, no error is raised when the task is allowed to be skipped."""
+        """Tests that even though a subtask is aborted, no error is raised when the task is allowed to be skipped."""
         request = MissionAction.Goal()
         request.subtasks = [
             SubtaskGoal(task_name="test/mock_subtask", task_data="{}", allow_skipping=True, task_id="123")
@@ -97,8 +97,9 @@ class MissionUnittest(unittest.TestCase):
         expected_result.mission_results = [
             SubtaskResult(task_name="test/mock_subtask", task_status=TaskStatus.ERROR, skipped=True, task_id="123")
         ]
-
-        result = self.mission.execute_cb(goal_handle=Mock(request=request))
+        mock_handle = Mock(request=request)
+        mock_handle.is_cancel_requested = False
+        result = self.mission.execute_cb(goal_handle=mock_handle)
         self.assertEqual(result, expected_result)
 
 


### PR DESCRIPTION
After some recent re-evaluations we have thought that it might make more sense for the Mission task to actually be cancelled on Stop. 

For example, you have a robot doing a mission of visiting many different locations, and then you press a big red Stop button: you expect the robot to stop, not to just skip the current location where it was going to and proceed to the next one. If you want to cancel only the current location, you do have the option to cancel that one task specifically, as long as you have `allow_skipping` enabled

Changes: 

- Changed the Mission specification to `cancel_on_stop=True`
- Removed some comments that didn't seem to make too much sense to me (I can add them again or modify if requested)
- Will skip a unsuccessful if the whole mission wasn't cancelled 
- Will cancel a mission if cancel was requested
- Will abort a mission if a subtask was unsuccessful and skipping is not allowed 