### PR TITLE
Check error flags when canceling an action task

### DIFF
--- a/task_manager/mypy.ini
+++ b/task_manager/mypy.ini
@@ -1,0 +1,56 @@
+[mypy]
+ignore_missing_imports = True
+
+# Python version to be compatible with
+python_version = 3.8
+
+#
+# Define type checking settings. These settings are pretty strict.
+#
+
+# Warns about per-module sections in the config file that do not match any files processed when invoking mypy.
+warn_unused_configs = True
+
+# Disallows usage of generic types that do not specify explicit type parameters.
+disallow_any_generics = True
+
+# Disallows subclassing a value of type Any.
+disallow_subclassing_any = True
+
+# Disallows calling functions without type annotations from functions with type annotations.
+# Hopefully this makes adding types more attractive.
+disallow_untyped_calls = True
+
+# Disallows defining functions without type annotations or with incomplete type annotations.
+disallow_untyped_defs = False
+
+# Disallows defining functions with incomplete type annotations.
+disallow_incomplete_defs = True
+
+# Type-checks the interior of functions without type annotations.
+check_untyped_defs = True
+
+# Reports an error whenever a function with type annotations is decorated with a decorator without annotations.
+disallow_untyped_decorators = True
+
+# Warns about casting an expression to its inferred type.
+warn_redundant_casts = True
+
+# Warns about unneeded # type: ignore comments.
+warn_unused_ignores = True
+
+# Shows errors for missing return statements on some execution paths.
+warn_return_any = True
+
+# Shows a warning when encountering any code inferred to be unreachable or redundant after performing type analysis.
+warn_unreachable = True
+
+# By default, imported values to a module are treated as exported and mypy allows other modules to import them. When
+# false, mypy will not re-export unless the item is imported using from-as or is included in __all__.
+implicit_reexport = false
+
+# Prohibit equality checks, identity checks, and container checks between non-overlapping types.
+strict_equality = True
+
+# Changes the treatment of arguments with a default value of None by not implicitly making their type Optional.
+no_implicit_optional = True

--- a/task_manager/task_manager/task_client.py
+++ b/task_manager/task_manager/task_client.py
@@ -217,7 +217,7 @@ class ActionTaskClient(TaskClient):
                 f"Goal seems to have already finished. Considering the task canceled."
             )
             if not self._result_future:
-                raise CancelTaskFailedError("Couldn't cancel the task, action result future does not exist!")
+                raise CancelTaskFailedError("Couldn't cancel the task result future since it does not exist!")
             self._result_future.cancel()
 
         else:

--- a/task_manager/task_manager/task_client.py
+++ b/task_manager/task_manager/task_client.py
@@ -196,8 +196,6 @@ class ActionTaskClient(TaskClient):
     def _handle_cancel_response(self, response: CancelGoal.Response) -> None:
         """Handles the response from the cancel request.
 
-        :raises UnknownIdAtCancelTaskError: If the goal with known id does not exist
-        :raises GoalAlreadyTerminatedAtCancelTaskError: If the goal has already terminated
         :raises CancelTaskFailedError: If the cancel request fails
         """
         # There seems to be a bug in rclpy, making the return code to be 0 (ERROR_NONE),
@@ -210,7 +208,7 @@ class ActionTaskClient(TaskClient):
                 f"Considering the task canceled."
             )
             if not self._result_future:
-                raise CancelTaskFailedError("Couldn't cancel the task, action result future does not exist!")
+                raise CancelTaskFailedError("Couldn't cancel the task result future since it does not exist!")
             self._result_future.cancel()
 
         elif response.return_code == CancelGoal.Response.ERROR_GOAL_TERMINATED:
@@ -234,8 +232,7 @@ class ActionTaskClient(TaskClient):
                 raise CancelTaskFailedError("Couldn't cancel the task!")
 
     def _goal_done_cb(self, future: Future) -> None:
-        """Called when the Action Client's goal finishes. Updates the task status and notifies callbacks further the
-        other callbacks.
+        """Called when the Action Client's goal finishes. Updates the task status and invokes task done callbacks.
 
         :param future: Future object giving the result of the action call.
         """

--- a/task_manager/task_manager/task_registrator.py
+++ b/task_manager/task_manager/task_registrator.py
@@ -146,7 +146,7 @@ class TaskRegistrator:
         active_task_clients = self._active_tasks.get_active_tasks_by_name(task_name)
         if not active_task_clients:
             return
-
+        self._node.get_logger().info(f"Detected running task of the same type '{task_name}', canceling it.")
         if len(active_task_clients) > 1:
             self._node.get_logger().error("Found multiple task clients with the same name!")
 
@@ -167,6 +167,7 @@ class TaskRegistrator:
             return
 
         try:
+            self._node.get_logger().info("Detected running blocking task, canceling it.")
             task_client.cancel_task()
         except CancelTaskFailedError as e:
             raise TaskStartError(

--- a/task_manager/test/integration_tests/mock_servers.py
+++ b/task_manager/test/integration_tests/mock_servers.py
@@ -18,10 +18,10 @@ import time
 
 # ROS
 import rclpy
-from rclpy.service import Service
 from rclpy.action.server import ActionServer, CancelResponse, ServerGoalHandle
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup, ReentrantCallbackGroup
 from rclpy.node import Node
+from rclpy.service import Service
 
 # ROS messages
 from example_interfaces.action import Fibonacci

--- a/task_manager/test/integration_tests/mock_servers.py
+++ b/task_manager/test/integration_tests/mock_servers.py
@@ -18,6 +18,7 @@ import time
 
 # ROS
 import rclpy
+from rclpy.service import Service
 from rclpy.action.server import ActionServer, CancelResponse, ServerGoalHandle
 from rclpy.callback_groups import MutuallyExclusiveCallbackGroup, ReentrantCallbackGroup
 from rclpy.node import Node
@@ -27,7 +28,7 @@ from example_interfaces.action import Fibonacci
 from example_interfaces.srv import AddTwoInts
 
 
-def create_fib_action_server(node, action_name):
+def create_fib_action_server(node: Node, action_name: str) -> ActionServer:
     """Action server that execution time depends on the given Fibonacci goal."""
     return ActionServer(
         node=node,
@@ -97,7 +98,7 @@ def _execute_cb(goal_handle: ServerGoalHandle) -> Fibonacci.Result:
     return result
 
 
-def create_add_two_ints_service(node: Node, service_name):
+def create_add_two_ints_service(node: Node, service_name: str) -> Service:
     """Creates a AddTwoInts service."""
 
     def service_callback(req: AddTwoInts.Request, result: AddTwoInts.Response) -> AddTwoInts.Response:

--- a/task_manager/test/integration_tests/test_action_task_client.py
+++ b/task_manager/test/integration_tests/test_action_task_client.py
@@ -213,7 +213,9 @@ class TestActionTaskClient(unittest.TestCase):
         client.start_task_async(Fibonacci.Goal(order=1))
         client.goal_done.wait(timeout=1)
         handle = ClientGoalHandle(
-            goal_id=client._goal_handle.goal_id, action_client=client._client, goal_response=Fibonacci.Result
+            goal_id=client._goal_handle.goal_id,  # type: ignore[union-attr]
+            action_client=client._client,
+            goal_response=Fibonacci.Result
         )
         client._goal_handle = handle
         client.cancel_task()
@@ -225,16 +227,18 @@ class TestActionTaskClient(unittest.TestCase):
         Checks that goal_cb is ran only once per goal and we do not throw error for the cancel.
         """
         client = ActionTaskClient(self._node, self._task_details, self._task_specs, action_clients={})
-        client.start_task_async(Fibonacci.Goal(order=1))
+        client.start_task_async(Fibonacci.Goal(order=0))
         client.goal_done.wait(timeout=1)
 
         # Reset state. Simulates a state where goal has finished but the response did not arrive to task manager
         handle = ClientGoalHandle(
-            goal_id=client._goal_handle.goal_id, action_client=client._client, goal_response=Fibonacci.Result
+            goal_id=client._goal_handle.goal_id,  # type: ignore[union-attr]
+            action_client=client._client,
+            goal_response=Fibonacci.Result
         )
         client._goal_handle = handle
-        client._result_future._done = False
-        client._result_future.add_done_callback(client._goal_done_cb)
+        client._result_future._done = False  # type: ignore[union-attr]
+        client._result_future.add_done_callback(client._goal_done_cb)  # type: ignore[union-attr]
         client.goal_done.clear()
 
         client.cancel_task()

--- a/task_manager/test/integration_tests/test_action_task_client.py
+++ b/task_manager/test/integration_tests/test_action_task_client.py
@@ -21,6 +21,7 @@ from time import sleep
 # ROS
 import rclpy
 from rclpy.action import CancelResponse, GoalResponse
+from rclpy.action.client import ClientGoalHandle
 from rclpy.executors import MultiThreadedExecutor
 
 # Thirdparty
@@ -190,6 +191,54 @@ class TestActionTaskClient(unittest.TestCase):
         self.assertEqual(client.task_details.status, TaskStatus.IN_PROGRESS)
         # Finally, wait for the goal to finish to avoid error logs
         client.goal_done.wait(timeout=5)
+
+    def test_cancel_task_goal_not_known_by_server(self) -> None:
+        """Action server doesn't know the goal when trying to cancel it."""
+        client = ActionTaskClient(self._node, self._task_details, self._task_specs, action_clients={})
+        client.start_task_async(Fibonacci.Goal(order=1))
+        self.fibonacci_server.destroy()
+        self.fibonacci_server = create_fib_action_server(self._node, "fibonacci")
+        client.cancel_task()
+        self.assertEqual(client.task_details.status, TaskStatus.CANCELED)
+
+    def test_goal_cb_called_only_once(self) -> None:
+        """Checks that goal_cb is ran only once per goal and we do not throw error for the cancel."""
+
+        def execute_cb(_goal_handle):
+            _goal_handle.succeed()
+            return Fibonacci.Result()
+
+        client = ActionTaskClient(self._node, self._task_details, self._task_specs, action_clients={})
+        self.fibonacci_server.register_execute_callback(execute_cb)
+        client.start_task_async(Fibonacci.Goal(order=1))
+        client.goal_done.wait(timeout=1)
+        handle = ClientGoalHandle(
+            goal_id=client._goal_handle.goal_id, action_client=client._client, goal_response=Fibonacci.Result
+        )
+        client._goal_handle = handle
+        client.cancel_task()
+        self.assertEqual(client.task_details.status, TaskStatus.DONE)
+
+    def test_cancel_task_goal_terminated_before_cancel(self) -> None:
+        """Case where the goal has already been finished when trying to cancel it.
+
+        Checks that goal_cb is ran only once per goal and we do not throw error for the cancel.
+        """
+        client = ActionTaskClient(self._node, self._task_details, self._task_specs, action_clients={})
+        client.start_task_async(Fibonacci.Goal(order=1))
+        client.goal_done.wait(timeout=1)
+
+        # Reset state. Simulates a state where goal has finished but the response did not arrive to task manager
+        handle = ClientGoalHandle(
+            goal_id=client._goal_handle.goal_id, action_client=client._client, goal_response=Fibonacci.Result
+        )
+        client._goal_handle = handle
+        client._result_future._done = False
+        client._result_future.add_done_callback(client._goal_done_cb)
+        client.goal_done.clear()
+
+        client.cancel_task()
+        self.assertEqual(client.task_details.status, TaskStatus.CANCELED)
 
 
 if __name__ == "__main__":

--- a/task_manager/test/integration_tests/test_action_task_client.py
+++ b/task_manager/test/integration_tests/test_action_task_client.py
@@ -38,7 +38,7 @@ from task_manager.task_client import ActionTaskClient, CancelTaskFailedError, Ta
 from task_manager.task_details import TaskDetails
 from task_manager.task_specs import TaskServerType, TaskSpecs
 
-# pylint: disable=duplicate-code
+# pylint: disable=duplicate-code, protected-access
 # The init is very similar to test_service_task_client, but it is fine in this case
 
 

--- a/task_manager/test/integration_tests/test_action_task_client.py
+++ b/task_manager/test/integration_tests/test_action_task_client.py
@@ -215,7 +215,7 @@ class TestActionTaskClient(unittest.TestCase):
         handle = ClientGoalHandle(
             goal_id=client._goal_handle.goal_id,  # type: ignore[union-attr]
             action_client=client._client,
-            goal_response=Fibonacci.Result
+            goal_response=Fibonacci.Result,
         )
         client._goal_handle = handle
         client.cancel_task()
@@ -234,7 +234,7 @@ class TestActionTaskClient(unittest.TestCase):
         handle = ClientGoalHandle(
             goal_id=client._goal_handle.goal_id,  # type: ignore[union-attr]
             action_client=client._client,
-            goal_response=Fibonacci.Result
+            goal_response=Fibonacci.Result,
         )
         client._goal_handle = handle
         client._result_future._done = False  # type: ignore[union-attr]

--- a/task_manager/test/integration_tests/test_action_task_client.py
+++ b/task_manager/test/integration_tests/test_action_task_client.py
@@ -224,7 +224,7 @@ class TestActionTaskClient(unittest.TestCase):
     def test_cancel_task_goal_terminated_before_cancel(self) -> None:
         """Case where the goal has already been finished when trying to cancel it.
 
-        Checks that goal_cb is ran only once per goal and we do not throw error for the cancel.
+        Checks that goal_done_cb is ran only once per goal and we do not throw error for the cancel.
         """
         client = ActionTaskClient(self._node, self._task_details, self._task_specs, action_clients={})
         client.start_task_async(Fibonacci.Goal(order=0))

--- a/task_manager/test/integration_tests/test_action_task_client.py
+++ b/task_manager/test/integration_tests/test_action_task_client.py
@@ -201,8 +201,8 @@ class TestActionTaskClient(unittest.TestCase):
         client.cancel_task()
         self.assertEqual(client.task_details.status, TaskStatus.CANCELED)
 
-    def test_goal_cb_called_only_once(self) -> None:
-        """Checks that goal_cb is ran only once per goal and we do not throw error for the cancel."""
+    def test_goal_done_cb_called_only_once(self) -> None:
+        """Checks that goal_done_cb is ran only once per goal and we do not throw error for the cancel."""
 
         def execute_cb(_goal_handle):
             _goal_handle.succeed()

--- a/task_manager/test/test_task_clients.py
+++ b/task_manager/test/test_task_clients.py
@@ -33,7 +33,7 @@ from example_interfaces.action import Fibonacci
 from task_manager_msgs.msg import TaskStatus
 
 # Task Manager
-from task_manager.task_client import ActionTaskClient, ServiceTaskClient, CancelTaskFailedError
+from task_manager.task_client import ActionTaskClient, CancelTaskFailedError, ServiceTaskClient
 from task_manager.task_details import TaskDetails
 
 # pylint: disable=protected-access

--- a/task_manager/test/test_task_clients.py
+++ b/task_manager/test/test_task_clients.py
@@ -15,7 +15,7 @@
 #  ------------------------------------------------------------------
 
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 # ROS
 from rclpy.node import Node
@@ -26,13 +26,14 @@ from rosbridge_library.internal.message_conversion import extract_values
 
 # ROS messages
 from action_msgs.msg import GoalStatus
+from action_msgs.srv import CancelGoal
 from example_interfaces.action import Fibonacci
 
 # Task Manager messages
 from task_manager_msgs.msg import TaskStatus
 
 # Task Manager
-from task_manager.task_client import ActionTaskClient, ServiceTaskClient
+from task_manager.task_client import ActionTaskClient, ServiceTaskClient, CancelTaskFailedError
 from task_manager.task_details import TaskDetails
 
 # pylint: disable=protected-access
@@ -87,6 +88,31 @@ class TestActionTaskClient(unittest.TestCase):
         # As a workaround, use extract_values-function to get the result in json format
         result = extract_values(task_client.task_details.result)
         self.assertEqual(result, {"sequence": []}, msg=str(task_client.task_details.result))
+
+    def test_cancel_task_no_goal_handle(self):
+        """Tests that we do not crash if goal handle does not exist."""
+        task_client = get_action_task_client("task_1")
+        self.assertRaises(CancelTaskFailedError, task_client.cancel_task)
+
+    def test_request_canceling_no_goal_handle(self):
+        """Tests that we do not crash if goal handle does not exist."""
+        task_client = get_action_task_client("task_1")
+        self.assertRaises(CancelTaskFailedError, task_client._request_canceling, 1)
+
+    @patch("task_manager.task_client.ActionTaskClient._request_canceling")
+    def test_cancel_task_no_result_future(self, mock_request_canceling: Mock):
+        """Tests that we do not crash if result future does not exist."""
+        cases = [
+            {"case": "Unknown goal id", "return_code": CancelGoal.Response.ERROR_UNKNOWN_GOAL_ID},
+            {"case": "Goal terminated", "return_code": CancelGoal.Response.ERROR_GOAL_TERMINATED},
+        ]
+
+        task_client = get_action_task_client("task_1")
+        task_client._goal_handle = Mock()
+        for case in cases:
+            mock_request_canceling.return_value = CancelGoal.Response(return_code=case["return_code"])
+            with self.subTest(case["case"]):
+                self.assertRaises(CancelTaskFailedError, task_client.cancel_task)
 
 
 class ServiceTaskClientUnittests(unittest.TestCase):


### PR DESCRIPTION
Adds check for the error flags present in the CancelGoal.Response message which we receive when canceling an action goal. Checking flags `ERROR_UNKNOWN_GOAL_ID` and `ERROR_GOAL_TERMINATED` to avoid falsely claiming a failure of cancellation if the goal is no longer valid (for example a case where the action server had restarted during the execution of a previous task and now a new task has been given).

Also added a simple mypy config.

Next future improvement in this regard will be to monitor the connection to the server during task execution. This could give more flexibility to some of the hard coded timeout limits for example. Also should work nicely for the service tasks as well.