### PR TITLE
Include error code into the TaskDoneResult message

### DIFF
--- a/task_manager/task_manager/task_manager_node.py
+++ b/task_manager/task_manager/task_manager_node.py
@@ -217,6 +217,7 @@ class TaskManager(Node):
                     task_id=request.task_id,
                     task_name=request.task_name,
                     task_status=response.task_status,
+                    error_code=response.error_code,
                     source=request.source,
                     task_result=response.task_result,
                 )

--- a/task_manager_msgs/msg/TaskDoneResult.msg
+++ b/task_manager_msgs/msg/TaskDoneResult.msg
@@ -1,5 +1,6 @@
 string task_id
 string task_name
 string task_status
+string error_code
 string source
 string task_result


### PR DESCRIPTION
The error code was previously only returned in the response for the action. Added the error code now into the TaskDoneResult message as well.

This change will give more important information for the applications which rely on the TaskDoneResult messages on the results topic.