### PR TITLE
Fix JSONDecodeError in task_action_server

### DIFF
--- a/task_manager/task_manager/active_tasks.py
+++ b/task_manager/task_manager/active_tasks.py
@@ -119,7 +119,7 @@ class ActiveTasks:
                 try:
                     task_client.cancel_task()
                 except CancelTaskFailedError as e:
-                    err_msg += f"{task_client.task_specs.task_name} ({str(e)}), "
+                    err_msg += f"{task_client.task_specs.task_name} ({repr(e)}), "
         if err_msg != "":
             raise CancelTaskFailedError(err_msg)
 

--- a/task_manager/task_manager/task_client.py
+++ b/task_manager/task_manager/task_client.py
@@ -193,7 +193,7 @@ class ActionTaskClient(TaskClient):
             self._wait_for_future_to_complete(future, timeout=timeout)
         except TimeoutError as e:
             self._node.get_logger().error(
-                f"Timeout while waiting response to cancel request from server {self.task_specs.task_name}: {str(e)}."
+                f"Timeout while waiting response to cancel request from server {self.task_specs.task_name}: {repr(e)}."
             )
             raise CancelTaskFailedError("Cancel request timed out.") from e
         return future.result()

--- a/task_manager/task_manager/task_manager_node.py
+++ b/task_manager/task_manager/task_manager_node.py
@@ -219,7 +219,7 @@ class TaskManager(Node):
         try:
             response.task_status, response.task_result = self._wait_for_task_finish(task_client, goal_handle)
         except CancelTaskFailedError as e:
-            self.get_logger().error(f"Failed to cancel a task {request.task_name}: {str(e)}")
+            self.get_logger().error(f"Failed to cancel a task {request.task_name}: {repr(e)}")
             response.task_status = TaskStatus.IN_PROGRESS
             response.error_code = response.ERROR_TASK_CANCEL_FAILED
 
@@ -243,13 +243,13 @@ class TaskManager(Node):
         try:
             task_client = self.task_registrator.start_new_task(request, self.known_tasks[request.task_name])
         except DuplicateTaskIdException as error_msg:
-            self.get_logger().error(str(error_msg))
+            self.get_logger().error(repr(error_msg))
             error_code = ExecuteTask.Result().ERROR_DUPLICATE_TASK_ID
         except ROSGoalParsingError as error_msg:
-            self.get_logger().error(str(error_msg))
+            self.get_logger().error(repr(error_msg))
             error_code = ExecuteTask.Result().ERROR_TASK_DATA_PARSING_FAILED
         except TaskStartError as error_msg:
-            self.get_logger().error(str(error_msg))
+            self.get_logger().error(repr(error_msg))
             error_code = ExecuteTask.Result().ERROR_TASK_START_ERROR
 
         return task_client, error_code

--- a/task_manager/task_manager/task_registrator.py
+++ b/task_manager/task_manager/task_registrator.py
@@ -189,7 +189,7 @@ def populate_msg(task_data: str, msg_interface: Any):
         raise ROSGoalParsingError(
             f"Unable to parse task data, check the message interface for the correct message data format. "
             f"{msg_interface} requires the following fields and types: {fields_and_types}. "
-            f"The Following error was received: {str(e)}"
+            f"The Following error was received: {repr(e)}"
         ) from e
     return task_goal_message
 

--- a/task_manager/test/test_task_action_server.py
+++ b/task_manager/test/test_task_action_server.py
@@ -36,6 +36,8 @@ from task_manager.task_specs import TaskServerType, TaskSpecs
 from task_manager.tasks.task_action_server import TaskActionServer
 
 
+# pylint: disable=protected-access
+
 class TestActionTaskClient(unittest.TestCase):
     """Integration tests for ActionTaskClient."""
 

--- a/task_manager/test/test_task_action_server.py
+++ b/task_manager/test/test_task_action_server.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+#  ------------------------------------------------------------------
+#   Copyright 2024 Karelics Oy
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#  ------------------------------------------------------------------
+
+import unittest
+from unittest.mock import Mock
+
+# ROS
+import rclpy
+from rclpy.action.server import ServerGoalHandle
+from rclpy.node import Node
+
+# ROS messages
+from example_interfaces.action import Fibonacci
+
+# Task Manager messages
+from task_manager_msgs.action import ExecuteTask
+from task_manager_msgs.msg import TaskDoneResult, TaskStatus
+
+# Task Manager
+from task_manager.task_specs import TaskServerType, TaskSpecs
+from task_manager.tasks.task_action_server import TaskActionServer
+
+
+class TestActionTaskClient(unittest.TestCase):
+    """Integration tests for ActionTaskClient."""
+
+    def setUp(self) -> None:
+        rclpy.init()
+        self._node = Node("test_node", namespace="/task_action_server_test")
+        self._task_specs = TaskSpecs(
+            task_name="test_task",
+            topic="/test_task_topic",
+            msg_interface=Fibonacci,
+            task_server_type=TaskServerType.ACTION,
+        )
+
+    def tearDown(self) -> None:
+        self._node.destroy_node()
+        rclpy.try_shutdown()
+
+    def test_task_action_server(self):
+        """Happy flow."""
+        task_action_server = TaskActionServer(
+            self._node, self._task_specs, "/test_topic_prefix", self._mock_execute_task_cb
+        )
+        goal_handle = Mock(spec=ServerGoalHandle)
+        goal_handle.request = Fibonacci.Goal()
+
+        response = task_action_server._execute_cb(goal_handle)
+
+        self.assertListEqual(list(response.sequence), [0, 1])
+        self.assertTrue(goal_handle.succeed.called)
+
+    def test_task_action_server_error(self):
+        """Error flow."""
+        task_action_server = TaskActionServer(
+            self._node, self._task_specs, "/test_topic_prefix", self._mock_execute_task_cb_error
+        )
+        goal_handle = Mock(spec=ServerGoalHandle)
+        goal_handle.request = Fibonacci.Goal()
+
+        response = task_action_server._execute_cb(goal_handle)
+
+        self.assertEqual(list(response.sequence), [])
+        self.assertTrue(goal_handle.abort.called)
+
+    @staticmethod
+    def _mock_execute_task_cb(_request: ExecuteTask.Goal, _goal_handle: ServerGoalHandle = None) -> ExecuteTask.Result:
+        """Mock execute task callback that returns a result."""
+        return TaskDoneResult(
+            task_id="test_task_id",
+            task_name="test_task",
+            task_status=TaskStatus.DONE,
+            error_code="",
+            source="TEST",
+            task_result='{"sequence": [0, 1]}',
+        )
+
+    @staticmethod
+    def _mock_execute_task_cb_error(
+        _request: ExecuteTask.Goal, _goal_handle: ServerGoalHandle = None
+    ) -> ExecuteTask.Result:
+        """Mock execute task callback that returns an error."""
+        return TaskDoneResult(
+            task_id="test_task_id_error",
+            task_name="test_task",
+            task_status=TaskStatus.ERROR,
+            error_code=ExecuteTask.Result().ERROR_TASK_DATA_PARSING_FAILED,
+            source="TEST",
+            task_result="{}",
+        )

--- a/task_manager/test/test_task_action_server.py
+++ b/task_manager/test/test_task_action_server.py
@@ -35,8 +35,8 @@ from task_manager_msgs.msg import TaskDoneResult, TaskStatus
 from task_manager.task_specs import TaskServerType, TaskSpecs
 from task_manager.tasks.task_action_server import TaskActionServer
 
-
 # pylint: disable=protected-access
+
 
 class TestActionTaskClient(unittest.TestCase):
     """Integration tests for ActionTaskClient."""


### PR DESCRIPTION
If task call was made to task_action_server and there was a failure on the task start the task_action_server would throw JSONDecodeError. This is caused by execute_task function in TaskManager object setting the task_result as "{}" which results to the failure of the `populate_instance` call.

Also changed all `str(e)` prints to `repr(e)` which gives a little bit more information of the error. These would have helped on finding the bug described above quite a lot faster.